### PR TITLE
Update deploy steps for newer Fly.io configurations

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,18 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+ARG RUBY_VERSION=3.3.4
+FROM ruby:$RUBY_VERSION-slim as base
+
+# Rack app lives here
+WORKDIR /app
+
+# Update gems and bundler
+RUN gem update --system --no-document && \
+    gem install -N bundler
+
+
+# Throw-away build stage to reduce size of final image
+FROM base as build
+
+# Install packages needed to build gems
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential
+
+# Install application gems
+COPY Gemfile* .
+RUN bundle install
+
+
+# Final stage for app image
+FROM base
+
+# Run and own the application files as a non-root user for security
+RUN useradd ruby --home /app --shell /bin/bash
+USER ruby:ruby
+
+# Copy built artifacts: gems, application
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build --chown=ruby:ruby /app /app
+
+# Copy application code
+COPY --chown=ruby:ruby . .
+
+# Start the server
+EXPOSE 8080
+CMD ["bundle", "exec", "rackup", "--host", "0.0.0.0", "--port", "8080"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '3.2.2'
+ruby '3.3.4'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 

--- a/README.md
+++ b/README.md
@@ -14,31 +14,6 @@ ruby lib/app.rb
 
 ## How to deploy
 
-### Install the Heroku CLI
+This deploys with [Fly.io](https://fly.io/apps/twab), upon a successful merge to `main`.
 
-Download and install [the Heroku CLI](https://devcenter.heroku.com/articles/heroku-command-line).
-
-If you haven't already, log in to your Heroku account and follow the prompts to create a new SSH public key.
-
-```
-heroku login
-```
-
-### Clone the repository
-
-Use Git to clone twab's source code to your local machine.
-
-```
-heroku git:clone -a twab
-cd twab
-```
-
-### Deploy your changes
-
-Make some changes to the code you just cloned and deploy them to Heroku using Git.
-
-```
-git add .
-git commit -am 'make it better'
-git push heroku main
-```
+[GitHub has a copy](https://github.com/michaelabon/twab/settings/secrets/actions) of a Fly.io API token that may need to be regenerated.

--- a/fly.toml
+++ b/fly.toml
@@ -1,39 +1,22 @@
-# fly.toml file generated for twab on 2022-08-31T14:35:26-05:00
+# fly.toml app configuration file generated for twab on 2024-07-22T12:02:13-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
-app = "twab"
+app = 'twab'
+primary_region = 'ord'
 
 [build]
-  builder = "heroku/buildpacks:20"
 
-[env]
-  PORT = "8080"
-
-[experimental]
-  allowed_public_ports = []
-  auto_rollback = true
-
-[[services]]
-  http_checks = []
+[http_service]
   internal_port = 8080
-  processes = ["app"]
-  protocol = "tcp"
-  script_checks = []
-  [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
-    type = "connections"
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
 
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
-
-  [[services.tcp_checks]]
-    grace_period = "1s"
-    interval = "15s"
-    restart_limit = 0
-    timeout = "2s"
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1


### PR DESCRIPTION
Fly no longer likes the buildpack deploy steps. They automatically generated a Dockerfile and are much happier to push that.