### PR TITLE
Group rubocop and its dependencies together in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
         "dependency-type": "all"
     labels:
       - "dependencies"
+    groups:
+      rubocop:
+        applies-to: "version-updates"
+        patterns:
+          - "rubocop*"
   -
     package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
When both the `rubocop` and `rubocop-ast` dependencies need to be upgraded, they should be done so together. I don't want to have to test them separately.